### PR TITLE
Add timestamps to all printed log entries

### DIFF
--- a/ci-build.js
+++ b/ci-build.js
@@ -9,7 +9,7 @@ const ciBuildJenkinsClient = new Jenkins(config.ciBuildApiUrl, config.ciBuildUse
 
 ciBuildJenkinsClient.getCurrentBuildStatus = function ()
 {
-    console.log(`Getting current build status on "${this.m_url}".`);
+    console.log('Getting current build status on "${this.m_url}".');
 
     const deferred = q.defer();
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+require('console-stamp')(console, 'HH:MM:ss.l');
+
 const chalk = require("chalk");
 const ciBuild = require("./ci-build");
 const ciDev = require("./ci-dev");

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^1.1.3",
+    "console-stamp": "^0.2.5",
     "q": "^1.4.1",
     "request": "^2.75.0"
   }


### PR DESCRIPTION
Often i'd want to know from looking at the console how long is left until the next poll, adding a timestamp makes this easy

Example new output:

```
[09:18:16.920] [LOG]   Testing Github authentication.
[09:18:17.289] [LOG]   Success.
[09:18:17.293] [LOG]   Testing Jenkins authentication on "https://ci-dev.tax.service.gov.uk/".
[09:18:18.063] [LOG]   Success.
[09:18:18.063] [LOG]   Testing Jenkins authentication on "https://ci-build.tax.service.gov.uk/".
[09:18:18.420] [LOG]   Success.
```